### PR TITLE
Keep images when converting

### DIFF
--- a/auto_markdown/config.json
+++ b/auto_markdown/config.json
@@ -4,7 +4,7 @@
         "uiEditFieldCheckbox": true
     },
     "code": {
-        "colorScheme": "default",
+        "colorScheme": "monokai",
         "lineNums": true
     },
     "manual": {

--- a/auto_markdown/editor.py
+++ b/auto_markdown/editor.py
@@ -22,7 +22,7 @@ import base64
 
 from . import config
 
-def simpleMarkdownFromHTML(html_text):
+def sanitize(html_text):
     """Converts various HTML objects in Anki generated HTML to markdown."""
     return (html_text
         .replace('<br>', '\n')
@@ -31,10 +31,11 @@ def simpleMarkdownFromHTML(html_text):
         .replace('&nbsp;', ' ')
         .replace('&lt;', '<')
         .replace('&gt;', '>')
+        .replace('&amp;', '&')
         )
 
 def generateHtmlFromMarkdown(field_plain, field_html):
-    sanitized_html = simpleMarkdownFromHTML(field_html)
+    sanitized_html = sanitize(field_html)
 
     generated_html = markdown.markdown(sanitized_html, extensions=[
         AbbrExtension(),

--- a/auto_markdown/editor.py
+++ b/auto_markdown/editor.py
@@ -22,13 +22,21 @@ import base64
 
 from . import config
 
-def generateHtmlFromMarkdown(field_plain, field_html):
-    if not field_plain:
-        field_plain = ""
-    else:
-        field_plain = field_plain.replace("\xc2\xa0", " ").replace("\xa0", " ") # non-breaking space
+def simpleMarkdownFromHTML(html_text):
+    """Converts various HTML objects in Anki generated HTML to markdown."""
+    return (html_text
+        .replace('<br>', '\n')
+        .replace('<div>', '\n')
+        .replace('</div>', '')
+        .replace('&nbsp;', ' ')
+        .replace('&lt;', '<')
+        .replace('&gt;', '>')
+        )
 
-    generated_html = markdown.markdown(field_plain, extensions=[
+def generateHtmlFromMarkdown(field_plain, field_html):
+    sanitized_html = simpleMarkdownFromHTML(field_html)
+
+    generated_html = markdown.markdown(sanitized_html, extensions=[
         AbbrExtension(),
         CodeHiliteExtension(
             noclasses = True, 


### PR DESCRIPTION
This PR changes the source of markdown conversion to a sanitised version of the HTML. This allows images to be kept when converting to markdown.

Fixes #4 .